### PR TITLE
Lower priority for scramblers not registered in the event

### DIFF
--- a/src/logic/groups.js
+++ b/src/logic/groups.js
@@ -390,7 +390,10 @@ const moveCompetitorToGroupEnd = (groups, fromGroupId, toGroupId, competitor) =>
   );
 
 const assignScrambling = (wcif, roundsToAssign) => {
-  const { noTasksForNewcomers } = getExtensionData('CompetitionConfig', wcif);
+  const { noTasksForNewcomers, tasksForOwnEventsOnly } = getExtensionData(
+    'CompetitionConfig',
+    wcif
+  );
   /* Sort rounds by the number of competitors, so the further the more people able to scramble there are. */
   const sortedRoundsToAssign = sortBy(
     roundsToAssign,
@@ -415,6 +418,10 @@ const assignScrambling = (wcif, roundsToAssign) => {
         const sortedAvailableStaff = sortByArray(
           available(staffScramblers),
           competitor => [
+            tasksForOwnEventsOnly &&
+            !competitor.registration.eventIds.includes(eventId)
+              ? 1
+              : -1,
             /* Avoid difference in the number of tasks bigger than 3.
              (General note: this is better than sorting by the number of tasks,
              as it allows one person to be assigned a couple times in a row). */
@@ -429,6 +436,10 @@ const assignScrambling = (wcif, roundsToAssign) => {
             : sortByArray(available(competitors), competitor => [
                 /* Optionally avoid assigning tasks to newcomers. */
                 noTasksForNewcomers && !competitor.wcaId ? 1 : -1,
+                tasksForOwnEventsOnly &&
+                !competitor.registration.eventIds.includes(eventId)
+                  ? 1
+                  : -1,
                 /* Strongly prefer people at least 10 years old. */
                 age(competitor) >= 10 ? -1 : 1,
                 /* Avoid assigning tasks to people already busy due to their role. */


### PR DESCRIPTION
At the moment, people with the "scrambler" role may be assigned for events they are not registered for, even if the "Assign tasks to competitors only in events they registered for" is checked.

I think it's fine if there are no other choice, but I think groupifier could try a bit harder to honor that option, and I think one way to do it is to add that parameter to the sorting array, similar to how it's done for judging/running (I realize that this means these people could staff more than others, but I think that's fine: if the organizers check the "own events" option it basically means the more you compete the more you staff).
If I haven't messed up my implementation (which I quickly tested against one of our competitions where we had the issue), here is the order of priority: scramblers registered in the event, scramblers, non-scramblers registered in the event, non-scramblers.

What do you think about this suggestion @jonatanklosko?