### PR TITLE
Add support for letter paper.

### DIFF
--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -36,7 +36,7 @@
     "scorecardPaperSize": {
       "description": "The size of paper that should be used for printing scorecards.",
       "type": "string",
-      "enum": ["a4", "a6"]
+      "enum": ["a4", "a6", "letter"]
     }
   },
   "required": ["localNamesFirst", "scorecardsBackgroundUrl", "competitorsSortingRule", "noTasksForNewcomers", "tasksForOwnEventsOnly"]

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -49,6 +49,10 @@ const scorecardPaperSizes = [
     name: 'Four scorecards per page (A4 paper)',
   },
   {
+    id: 'letter',
+    name: 'Four scorecards per page (Letter paper, used in North America)',
+  },
+  {
     id: 'a6',
     name: 'One scorecard per page (A6 paper)',
   },

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -31,6 +31,12 @@ const scorecardPaperSizeInfos = {
     scorecardsPerRow: 1,
     scorecardsPerPage: 1,
   },
+  letter: {
+    pageWidth: 612.0,
+    pageHeight: 792.0,
+    scorecardsPerRow: 2,
+    scorecardsPerPage: 4,
+  },
 };
 const scorecardMargin = 20;
 


### PR DESCRIPTION
This is the main type of paper used in the US and Canada. A4 is slightly longer, and so A4 scorecards printed on letter paper slightly cut off at the bottom.

Comparison: left is with this PR; right is using A4 layout on letter paper
![PXL_20230129_182137213](https://user-images.githubusercontent.com/3885929/215347652-477b810e-f9ee-4c1f-823a-29cc5c372052.jpg)
