### PR TITLE
Add an option for printing scorecards in stacks.

### DIFF
--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -38,10 +38,10 @@
       "type": "string",
       "enum": ["a4", "a6", "letter"]
     },
-    "scorecardSortOrder": {
+    "scorecardOrder": {
       "description": "Whether scorecards should be printed in overall ascending order (1-2-3-4 5-6-7-8 9-10-11-12), or ascending order within each section of the page (1-4-7-10 2-5-8-11 3-6-9-12)",
       "type": "string",
-      "enum": ["overall", "by-page-section"]
+      "enum": ["natural", "stacked"]
     }
   },
   "required": ["localNamesFirst", "scorecardsBackgroundUrl", "competitorsSortingRule", "noTasksForNewcomers", "tasksForOwnEventsOnly"]

--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -37,6 +37,11 @@
       "description": "The size of paper that should be used for printing scorecards.",
       "type": "string",
       "enum": ["a4", "a6", "letter"]
+    },
+    "scorecardSortOrder": {
+      "description": "Whether scorecards should be printed in overall ascending order (1-2-3-4 5-6-7-8 9-10-11-12), or ascending order within each section of the page (1-4-7-10 2-5-8-11 3-6-9-12)",
+      "type": "string",
+      "enum": ["overall", "by-page-section"]
     }
   },
   "required": ["localNamesFirst", "scorecardsBackgroundUrl", "competitorsSortingRule", "noTasksForNewcomers", "tasksForOwnEventsOnly"]

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -60,13 +60,14 @@ const scorecardPaperSizes = [
 
 const scorecardSortingRules = [
   {
-    id: 'overall',
-    name: 'Sort scorecards overall (1/2/3/4 5/6/7/8 9/10/11/12)',
+    id: 'naturall',
+    name:
+      'Scorecards are arranged by row, page by page (1/2/3/4 5/6/7/8 9/10/11/12)',
   },
   {
-    id: 'by-page-section',
+    id: 'stacked',
     name:
-      'Sort scorecards so that each stack of scorecards is sorted (1/4/7/10 2/5/8/11 3/6/9/12)',
+      'Scorecards are arranged such that each stack of scorecards is sorted (1/4/7/10 2/5/8/11 3/6/9/12)',
   },
 ];
 
@@ -100,7 +101,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     scorecardsBackgroundUrl,
     printStations,
     scorecardPaperSize,
-    scorecardSortOrder,
+    scorecardOrder,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -203,14 +204,14 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
           <Grid item>
             <FormControl fullWidth>
               <InputLabel htmlFor="scorecard-sort-order">
-                Scorecard Sort Order
+                Scorecard order
               </InputLabel>
               <Select
-                value={scorecardSortOrder}
+                value={scorecardOrder}
                 onChange={handleTextFieldChange}
                 inputProps={{
-                  name: 'scorecardSortOrder',
-                  id: 'scorecard-sort-order',
+                  name: 'scorecardOrder',
+                  id: 'scorecard-order',
                 }}
               >
                 {scorecardSortingRules.map(({ id, name }) => (

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -58,6 +58,18 @@ const scorecardPaperSizes = [
   },
 ];
 
+const scorecardSortingRules = [
+  {
+    id: 'overall',
+    name: 'Sort scorecards overall (1/2/3/4 5/6/7/8 9/10/11/12)',
+  },
+  {
+    id: 'by-page-section',
+    name:
+      'Sort scorecards so that each stack of scorecards is sorted (1/4/7/10 2/5/8/11 3/6/9/12)',
+  },
+];
+
 const GeneralConfig = ({ wcif, onWcifChange }) => {
   const handlePropertyChange = (property, value) => {
     onWcifChange(
@@ -88,6 +100,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     scorecardsBackgroundUrl,
     printStations,
     scorecardPaperSize,
+    scorecardSortOrder,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -180,6 +193,27 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
                 }}
               >
                 {scorecardPaperSizes.map(({ id, name }) => (
+                  <MenuItem value={id} key={id}>
+                    {name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item>
+            <FormControl fullWidth>
+              <InputLabel htmlFor="scorecard-sort-order">
+                Scorecard Sort Order
+              </InputLabel>
+              <Select
+                value={scorecardSortOrder}
+                onChange={handleTextFieldChange}
+                inputProps={{
+                  name: 'scorecardSortOrder',
+                  id: 'scorecard-sort-order',
+                }}
+              >
+                {scorecardSortingRules.map(({ id, name }) => (
                   <MenuItem value={id} key={id}>
                     {name}
                   </MenuItem>

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -167,8 +167,10 @@ const scorecards = (wcif, rounds, rooms) => {
     localNamesFirst,
     printStations,
     scorecardPaperSize,
+    scorecardSortOrder,
   } = getExtensionData('CompetitionConfig', wcif);
-  return flatMap(rounds, round => {
+  const { scorecardsPerPage } = scorecardPaperSizeInfos[scorecardPaperSize];
+  let cards = flatMap(rounds, round => {
     const groupsWithCompetitors = groupActivitiesWithCompetitors(
       wcif,
       round.id
@@ -200,11 +202,9 @@ const scorecards = (wcif, rounds, rooms) => {
               scorecardPaperSize,
             })
         );
-        const { scorecardsPerPage } = scorecardPaperSizeInfos[
-          scorecardPaperSize
-        ];
         const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;
-        return scorecardsOnLastPage === 0
+        return scorecardsOnLastPage === 0 ||
+          scorecardSortOrder === 'by-page-section'
           ? groupScorecards
           : groupScorecards.concat(
               times(scorecardsPerPage - scorecardsOnLastPage, () => ({}))
@@ -212,6 +212,30 @@ const scorecards = (wcif, rounds, rooms) => {
       }
     );
   });
+  if (scorecardSortOrder === 'by-page-section') {
+    const scorecardsOnLastPage = cards.length % scorecardsPerPage;
+    if (scorecardsOnLastPage !== 0) {
+      cards = cards.concat(
+        times(scorecardsPerPage - scorecardsOnLastPage, () => ({}))
+      );
+    }
+    cards = cards
+      .map((card, idx) => {
+        return { overallNumber: idx, card };
+      })
+      .sort((cardA, cardB) => {
+        const sectionA =
+          cardA.overallNumber % (cards.length / scorecardsPerPage);
+        const sectionB =
+          cardB.overallNumber % (cards.length / scorecardsPerPage);
+        if (sectionA !== sectionB) {
+          return sectionA - sectionB;
+        }
+        return cardA.overallNumber - cardB.overallNumber;
+      })
+      .map(card => card.card);
+  }
+  return cards;
 };
 
 const groupActivitiesWithCompetitors = (wcif, roundId) => {

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -167,7 +167,7 @@ const scorecards = (wcif, rounds, rooms) => {
     localNamesFirst,
     printStations,
     scorecardPaperSize,
-    scorecardSortOrder,
+    scorecardOrder,
   } = getExtensionData('CompetitionConfig', wcif);
   const { scorecardsPerPage } = scorecardPaperSizeInfos[scorecardPaperSize];
   let cards = flatMap(rounds, round => {
@@ -203,8 +203,7 @@ const scorecards = (wcif, rounds, rooms) => {
             })
         );
         const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;
-        return scorecardsOnLastPage === 0 ||
-          scorecardSortOrder === 'by-page-section'
+        return scorecardsOnLastPage === 0 || scorecardOrder === 'stacked'
           ? groupScorecards
           : groupScorecards.concat(
               times(scorecardsPerPage - scorecardsOnLastPage, () => ({}))
@@ -212,7 +211,7 @@ const scorecards = (wcif, rounds, rooms) => {
       }
     );
   });
-  if (scorecardSortOrder === 'by-page-section') {
+  if (scorecardOrder === 'stacked') {
     const scorecardsOnLastPage = cards.length % scorecardsPerPage;
     if (scorecardsOnLastPage !== 0) {
       cards = cards.concat(

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -33,7 +33,7 @@ const defaultExtensionData = {
     noRunningForForeigners: false,
     printStations: false,
     scorecardPaperSize: 'a4',
-    scorecardSortOrder: 'overall',
+    scorecardSortOrder: 'natural',
   },
 };
 

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -33,6 +33,7 @@ const defaultExtensionData = {
     noRunningForForeigners: false,
     printStations: false,
     scorecardPaperSize: 'a4',
+    scorecardSortOrder: 'overall',
   },
 };
 


### PR DESCRIPTION
This option makes it much easier to sort cards -- we can just keep the top-left stack together, then the top-right, then the bottom-left, then the bottom-right.

Fixes #57.