### PR TITLE
Add a star to the upper-right of some scorecards

### DIFF
--- a/public/wcif-extensions/ActivityConfig.json
+++ b/public/wcif-extensions/ActivityConfig.json
@@ -28,6 +28,10 @@
     "assignJudges": {
       "description": "A flag indicating whether judges should be assigned to the given activity.",
       "type": "boolean"
+    },
+    "featuredCompetitorIds": {
+      "description": "A list of competitors' WCA user IDs who should have a star printed on their scorecard, for special handling by runners or scramblers.",
+      "type": "list",
     }
   },
   "required": ["capacity", "groups", "scramblers", "runners", "assignJudges"]

--- a/public/wcif-extensions/ActivityConfig.json
+++ b/public/wcif-extensions/ActivityConfig.json
@@ -29,7 +29,7 @@
       "description": "A flag indicating whether judges should be assigned to the given activity.",
       "type": "boolean"
     },
-    "featuredCompetitorIds": {
+    "featuredCompetitorWcaUserIds": {
       "description": "A list of competitors' WCA user IDs who should have a star printed on their scorecard, for special handling by runners or scramblers.",
       "type": "list",
     }

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -185,6 +185,10 @@ const scorecards = (wcif, rounds, rooms) => {
     return flatMap(
       groupsWithCompetitors,
       ([groupActivity, competitorsWithStation]) => {
+        const { featuredCompetitorIds } = getExtensionData(
+          'ActivityConfig',
+          groupActivity
+        );
         let scorecardInGroupNumber = competitorsWithStation.length;
         const groupScorecards = competitorsWithStation.map(
           ([competitor, stationNumber]) =>
@@ -200,6 +204,7 @@ const scorecards = (wcif, rounds, rooms) => {
               localNamesFirst,
               printStations,
               scorecardPaperSize,
+              featured: featuredCompetitorIds.includes(competitor.wcaUserId),
             })
         );
         const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;
@@ -309,6 +314,7 @@ const scorecard = ({
   localNamesFirst = false,
   printStations,
   scorecardPaperSize,
+  featured = false,
 }) => {
   const { eventId, roundNumber, groupNumber } = activityCode
     ? parseActivityCode(activityCode)
@@ -323,8 +329,20 @@ const scorecard = ({
 
   return [
     {
-      text: scorecardNumber && `${scorecardNumber}`,
       fontSize: 10,
+      columns: [
+        {
+          text: scorecardNumber && `${scorecardNumber}`,
+          alignment: 'left',
+        },
+        featured
+          ? {
+              text: '★',
+              font: 'WenQuanYiZenHei', // Roboto (default) does not support unicode icons like ★
+              alignment: 'right',
+            }
+          : {},
+      ],
     },
     {
       text: competitionName,

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -185,7 +185,7 @@ const scorecards = (wcif, rounds, rooms) => {
     return flatMap(
       groupsWithCompetitors,
       ([groupActivity, competitorsWithStation]) => {
-        const { featuredCompetitorIds } = getExtensionData(
+        const { featuredCompetitorWcaUserIds } = getExtensionData(
           'ActivityConfig',
           groupActivity
         );
@@ -204,7 +204,9 @@ const scorecards = (wcif, rounds, rooms) => {
               localNamesFirst,
               printStations,
               scorecardPaperSize,
-              featured: featuredCompetitorIds.includes(competitor.wcaUserId),
+              featured: featuredCompetitorWcaUserIds.includes(
+                competitor.wcaUserId
+              ),
             })
         );
         const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -20,6 +20,7 @@ export const setExtensionData = (extensionName, wcifEntity, data) => {
 };
 
 const defaultExtensionData = {
+  /* This always gets generated, so we don't need defaults for other fields */
   ActivityConfig: {
     featuredCompetitorWcaUserIds: [],
   },

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -20,7 +20,9 @@ export const setExtensionData = (extensionName, wcifEntity, data) => {
 };
 
 const defaultExtensionData = {
-  ActivityConfig: null /* This always gets generated, so it's fine for it to be null until then. */,
+  ActivityConfig: {
+    featuredCompetitorWcaUserIds: [],
+  },
   RoomConfig: {
     stations: null,
   },


### PR DESCRIPTION
This adds an option to the ActivityConfig WCIF extension; when this is set, the specified competitors will have a star in the upper right. This may be used in major competitions to indicate which competitors should solve on camera for the live stream.

This doesn't provide any logic for marking competitors as featured. For CubingUSA Nationals we'll be using another program for generating groups, and Groupifier scorecards. If other competitions would find this useful, a UI could be built to mark certain competitors as featured, but I'm not sure how often this would be useful.

[Sample scorecards](https://github.com/jonatanklosko/groupifier/files/10915319/CubingUSANationals2023-scorecards.3.pdf) (see page 5 for example). **Note** to anyone who happens to see this: these are not the real groups for Nationals :)