### PR TITLE
Add Delegate initials line to scorecards and group cover sheets

### DIFF
--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -102,7 +102,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     printStations,
     scorecardPaperSize,
     scorecardOrder,
-    includeCoverSheets,
+    printScorecardsCoverSheets,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -227,12 +227,12 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
             <FormControlLabel
               control={
                 <Checkbox
-                  name="includeCoverSheets"
-                  checked={includeCoverSheets}
+                  name="printScorecardsCoverSheets"
+                  checked={printScorecardsCoverSheets}
                   onChange={handleCheckboxChange}
                 />
               }
-              label="Include cover sheets"
+              label="Print cover sheets for scorecards"
             />
           </Grid>
           <Grid item>

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -102,6 +102,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     printStations,
     scorecardPaperSize,
     scorecardOrder,
+    includeCoverSheets,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -222,16 +223,30 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
               </Select>
             </FormControl>
           </Grid>
-          <FormControlLabel
-            control={
-              <Checkbox
-                name="localNamesFirst"
-                checked={localNamesFirst}
-                onChange={handleCheckboxChange}
-              />
-            }
-            label="Swap latin names with local ones"
-          />
+          <Grid item>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="includeCoverSheets"
+                  checked={includeCoverSheets}
+                  onChange={handleCheckboxChange}
+                />
+              }
+              label="Include cover sheets"
+            />
+          </Grid>
+          <Grid item>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="localNamesFirst"
+                  checked={localNamesFirst}
+                  onChange={handleCheckboxChange}
+                />
+              }
+              label="Swap latin names with local ones"
+            />
+          </Grid>
           <Grid>
             <FormControlLabel
               control={

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -485,7 +485,7 @@ const coverSheet = ({
       alignment: 'center',
     },
     {
-      text: `${room.name}: Group ${groupNumber}`, // TODO: make aware of room/stage
+      text: `Group ${groupNumber} (${room.name})`,
       fontSize: 15,
       margin: [0, 6],
       alignment: 'center',

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -170,7 +170,7 @@ const scorecards = (wcif, rounds, rooms) => {
     printStations,
     scorecardPaperSize,
     scorecardOrder,
-    includeCoverSheets,
+    printScorecardsCoverSheets,
   } = getExtensionData('CompetitionConfig', wcif);
   const { scorecardsPerPage } = scorecardPaperSizeInfos[scorecardPaperSize];
   let cards = flatMap(rounds, round => {
@@ -191,7 +191,7 @@ const scorecards = (wcif, rounds, rooms) => {
         const { featuredCompetitorWcaUserIds = [] } =
           getExtensionData('ActivityConfig', groupActivity) || {};
         let scorecardInGroupNumber = competitorsWithStation.length;
-        const groupCoverSheet = includeCoverSheets
+        const groupCoverSheet = printScorecardsCoverSheets
           ? coverSheet({
               competitionName: wcif.shortName,
               activityCode: groupActivity.activityCode,

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -428,7 +428,7 @@ const scorecard = ({
           ...attemptRows(cutoff, attemptCount, scorecardWidth),
           [
             {
-              text: 'Extra attempt (Delegate initials _______).',
+              text: 'Extra attempt (Delegate initials _______)',
               ...noBorder,
               colSpan: 5,
               margin: [0, 1],
@@ -549,7 +549,7 @@ const coverSheet = ({
 };
 
 const initialsField = (person = 'Delegate') => ({
-  text: [{ text: `${person} Initials`, bold: true }, ' ______'],
+  text: [{ text: `${person} initials`, bold: true }, ' ______'],
   alignment: 'center',
   fontSize: 10,
 });

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -521,7 +521,7 @@ const coverSheet = ({
       fontSize: 10,
       margin: [20, 6, 0, 6],
     },
-    initialsField(),
+    initialsField('Delegate'),
     {
       text: '-------------------- FOR DATA ENTRY --------------------',
       alignment: 'center',
@@ -538,17 +538,17 @@ const coverSheet = ({
       fontSize: 10,
       margin: [20, 6, 0, 6],
     },
-    initialsField(),
+    initialsField('Delegate'),
     {
       text: '6. Results checked by Delegate',
       fontSize: 10,
       margin: [20, 6, 0, 6],
     },
-    initialsField(),
+    initialsField('Delegate'),
   ];
 };
 
-const initialsField = (person = 'Delegate') => ({
+const initialsField = (person) => ({
   text: [{ text: `${person} initials`, bold: true }, ' ______'],
   alignment: 'center',
   fontSize: 10,

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -170,6 +170,7 @@ const scorecards = (wcif, rounds, rooms) => {
     printStations,
     scorecardPaperSize,
     scorecardOrder,
+    includeCoverSheets,
   } = getExtensionData('CompetitionConfig', wcif);
   const { scorecardsPerPage } = scorecardPaperSizeInfos[scorecardPaperSize];
   let cards = flatMap(rounds, round => {
@@ -190,6 +191,14 @@ const scorecards = (wcif, rounds, rooms) => {
         const { featuredCompetitorWcaUserIds = [] } =
           getExtensionData('ActivityConfig', groupActivity) || {};
         let scorecardInGroupNumber = competitorsWithStation.length;
+        const groupCoverSheet = includeCoverSheets
+          ? coverSheet({
+              competitionName: wcif.shortName,
+              activityCode: groupActivity.activityCode,
+              numberOfScorecards: competitorsWithStation.length,
+              room: roomByActivity(wcif, groupActivity.id),
+            })
+          : null;
         const groupScorecards = competitorsWithStation.map(
           ([competitor, stationNumber]) =>
             scorecard({
@@ -209,6 +218,9 @@ const scorecards = (wcif, rounds, rooms) => {
               ),
             })
         );
+        if (groupCoverSheet) {
+          groupScorecards.unshift(groupCoverSheet);
+        }
         const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;
         return scorecardsOnLastPage === 0 || scorecardOrder === 'stacked'
           ? groupScorecards
@@ -447,6 +459,100 @@ const scorecard = ({
     },
   ];
 };
+
+const coverSheet = ({
+  competitionName,
+  activityCode,
+  numberOfScorecards,
+  room,
+}) => {
+  const { eventId, roundNumber, groupNumber } = activityCode
+    ? parseActivityCode(activityCode)
+    : {};
+
+  return [
+    {
+      text: competitionName,
+      bold: true,
+      fontSize: 15,
+      margin: [0, 6],
+      alignment: 'center',
+    },
+    {
+      text: `${eventNameById(eventId)} Round ${roundNumber}`,
+      fontSize: 15,
+      margin: [0, 6],
+      alignment: 'center',
+    },
+    {
+      text: `${room.name}: Group ${groupNumber}`, // TODO: make aware of room/stage
+      fontSize: 15,
+      margin: [0, 6],
+      alignment: 'center',
+    },
+    {
+      text: '-------------------- FOR DELEGATE --------------------',
+      alignment: 'center',
+      margin: [0, 6],
+    },
+    {
+      text: [
+        '1. Bundled all ',
+        { text: numberOfScorecards, bold: true },
+        ' scorecards ',
+        { text: '□', font: 'WenQuanYiZenHei' },
+      ],
+      fontSize: 10,
+      alignment: 'left',
+      margin: [20, 6, 0, 6],
+    },
+    {
+      text: [
+        '2. Checked for missing signatures ',
+        { text: '□', font: 'WenQuanYiZenHei' },
+      ],
+      fontSize: 10,
+      font: 'WenQuanYiZenHei',
+      alignment: 'left',
+      margin: [20, 6, 0, 6],
+    },
+    {
+      text: '3. Number of scorecards with incidents: ______',
+      fontSize: 10,
+      margin: [20, 6, 0, 6],
+    },
+    initialsField(),
+    {
+      text: '-------------------- FOR DATA ENTRY --------------------',
+      alignment: 'center',
+      margin: [0, 6],
+    },
+    {
+      text: '4. Results entered by Scoretaker',
+      fontSize: 10,
+      margin: [20, 6, 0, 6],
+    },
+    initialsField('Scoretaker'),
+    {
+      text: '5. Incidents logged by Delegate',
+      fontSize: 10,
+      margin: [20, 6, 0, 6],
+    },
+    initialsField(),
+    {
+      text: '6. Results checked by Delegate',
+      fontSize: 10,
+      margin: [20, 6, 0, 6],
+    },
+    initialsField(),
+  ];
+};
+
+const initialsField = (person = 'Delegate') => ({
+  text: [{ text: `${person} Initials`, bold: true }, ' ______'],
+  alignment: 'center',
+  fontSize: 10,
+});
 
 const columnLabels = (labels, style = {}) =>
   labels.map(label => ({

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -416,7 +416,7 @@ const scorecard = ({
           ...attemptRows(cutoff, attemptCount, scorecardWidth),
           [
             {
-              text: 'Extra attempt',
+              text: 'Extra attempt (Delegate initials _______).',
               ...noBorder,
               colSpan: 5,
               margin: [0, 1],

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -35,6 +35,7 @@ const defaultExtensionData = {
     printStations: false,
     scorecardPaperSize: 'a4',
     scorecardOrder: 'natural',
+    includeCoverSheets: false,
   },
 };
 

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -35,7 +35,7 @@ const defaultExtensionData = {
     printStations: false,
     scorecardPaperSize: 'a4',
     scorecardOrder: 'natural',
-    includeCoverSheets: false,
+    printScorecardsCoverSheets: false,
   },
 };
 


### PR DESCRIPTION
These are some awesome features from Sarah Strong's scorecard design (full credit to her for these ideas!) that I am interested in porting to Groupifier. These two features are pretty much the only thing stopping me from using Groupifier for competitions where I am tasked with printing scorecards.

The Delegate initials line is pretty self explanatory. On the front of a scorecard, a Delegate should sign off when they authorize an extra or provisional:
![image](https://github.com/jonatanklosko/groupifier/assets/48423418/e9b00e21-32da-47e5-9ea6-add540feb5e2)

The group cover sheet helps with group consolidation (checking that you have all the scorecards, there are no missing signatures and marking if there are incidents) and facilitating data entry, score checking and incident logging in an organized manner (the Scoretaker and Delegates sign off when each task is complete):

![image](https://github.com/jonatanklosko/groupifier/assets/48423418/365d77c2-5ab3-4124-a422-760f79680add)

I've added a config option for this: 

![image](https://github.com/jonatanklosko/groupifier/assets/48423418/df1f3178-2bba-45bc-9aa1-ddc1ddb45cfd)

Notes:
- I figured making a quick PR was easier than opening an issue since the changes are pretty simple and it's easier for me to express ideas in code. @jonatanklosko, if you're ok with the general idea, then I will add unit tests and of course make any necessary code changes :)
- I could see the "Delegate initials" being a config option too.