### PR TITLE
Display "New Competitor" instead of blank WCA ID on scorecards

### DIFF
--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -279,7 +279,7 @@ const groupActivitiesWithCompetitors = (wcif, roundId) => {
       : sortedGroupActivitiesWithSize(wcif, roundId, expectedCompetitorCount);
     return groupsWithSize.map(([groupActivity, size]) => [
       groupActivity,
-      times(size, () => [{ name: ' ', registrantId: ' ' }, null]),
+      times(size, () => [{ name: null, registrantId: null }, null]),
     ]);
   }
 };
@@ -312,7 +312,7 @@ const scorecard = ({
   activityCode,
   round,
   attemptCount = 5,
-  competitor = { name: ' ', registrantId: ' ', wcaId: null },
+  competitor = { name: null, registrantId: null, wcaId: null },
   localNamesFirst = false,
   printStations,
   scorecardPaperSize,
@@ -389,15 +389,15 @@ const scorecard = ({
                   competitor.wcaId ||
                   // If the competitor has a name, then this is a new competitor
                   // Else this is a blank scorecard
-                  (competitor.name.trim().length > 0 ? 'New competitor' : ' '),
+                  (competitor.name ? 'New competitor' : ' '),
                 alignment: 'right',
               },
             ],
           ]),
           [
-            { text: competitor.registrantId, alignment: 'center' },
+            { text: competitor.registrantId || ' ', alignment: 'center' },
             {
-              text: pdfName(competitor.name, {
+              text: pdfName(competitor.name || ' ', {
                 swapLatinWithLocalNames: localNamesFirst,
               }),
               maxHeight: 20 /* See: https://github.com/bpampuch/pdfmake/issues/264#issuecomment-108347567 */,

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -384,7 +384,14 @@ const scorecard = ({
             'ID',
             [
               { text: 'Name', alignment: 'left', width: 'auto' },
-              { text: competitor.wcaId || ' ', alignment: 'right' },
+              {
+                text:
+                  competitor.wcaId ||
+                  // If the competitor has a name, then this is a new competitor
+                  // Else this is a blank scorecard
+                  (competitor.name.trim().length > 0 ? 'New Competitor' : ' '),
+                alignment: 'right',
+              },
             ],
           ]),
           [

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -389,7 +389,7 @@ const scorecard = ({
                   competitor.wcaId ||
                   // If the competitor has a name, then this is a new competitor
                   // Else this is a blank scorecard
-                  (competitor.name.trim().length > 0 ? 'New Competitor' : ' '),
+                  (competitor.name.trim().length > 0 ? 'New competitor' : ' '),
                 alignment: 'right',
               },
             ],


### PR DESCRIPTION
Another small suggestion. Display "New Competitor" instead of nothing.

| Scenario | Expected | Output |
| ----- | ----- | ----- |
|  New competitor  | Says "New Competitor" | <img src="https://github.com/jonatanklosko/groupifier/assets/48423418/2f125c5b-b567-4d13-86f5-11a483e64ba8" width=200>  |
|  Returning competitor  | Has WCA ID | <img src="https://github.com/jonatanklosko/groupifier/assets/48423418/f1a2f8ea-a8c4-4162-9243-70de8c58bcdc" width=200> |
|  Blank second round scorecard | Remains blank | <img src="https://github.com/jonatanklosko/groupifier/assets/48423418/e35560fb-8975-41a1-ad8f-6221c5c4867f" width=200> |
|  Blank scorecard | Remains blank |<img src="https://github.com/jonatanklosko/groupifier/assets/48423418/1a18b557-b1bb-4364-b90c-d4454bb5b6ac" width=200> |

Example PDFs:
- [ApplebySummerB2023-scorecards-461a39749f9f2b94c159d540f55fc14f6fcb8cff.pdf](https://github.com/jonatanklosko/groupifier/files/12283509/ApplebySummerB2023-scorecards-461a39749f9f2b94c159d540f55fc14f6fcb8cff.pdf)
- [ApplebySummerB2023-blank-scorecards-461a39749f9f2b94c159d540f55fc14f6fcb8cff.pdf](https://github.com/jonatanklosko/groupifier/files/12283510/ApplebySummerB2023-blank-scorecards-461a39749f9f2b94c159d540f55fc14f6fcb8cff.pdf)

Thanks! :)