### PR TITLE
Support double scrambler sign box

### DIFF
--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -103,6 +103,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     scorecardPaperSize,
     scorecardOrder,
     printScorecardsCoverSheets,
+    printSecondScrambler,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -245,6 +246,18 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
                 />
               }
               label="Swap latin names with local ones"
+            />
+          </Grid>
+          <Grid>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="printSecondScrambler"
+                  checked={printSecondScrambler}
+                  onChange={handleCheckboxChange}
+                />
+              }
+              label="Print out second scrambler sign box"
             />
           </Grid>
           <Grid>


### PR DESCRIPTION
This partially solves #79, it only remains to implement the logic to select the competitors that should have the second scrambler column. Without that logic, I don't see this feature very useful and, whith this design, it also takes a lot of space away from the result column.