### PR TITLE
Add assignments count to roles manager

### DIFF
--- a/src/components/Competition/RolesManager/RolesManager.js
+++ b/src/components/Competition/RolesManager/RolesManager.js
@@ -19,6 +19,7 @@ import InfoIcon from '@material-ui/icons/Info';
 import SaveWcifButton from '../../common/SaveWcifButton/SaveWcifButton';
 import { acceptedPeople } from '../../../logic/competitors';
 import { difference, sortBy } from '../../../logic/utils';
+import { anyCompetitorAssignment } from '../../../logic/assignments';
 
 const roles = [
   { id: 'staff-scrambler', name: 'Scrambler' },
@@ -131,6 +132,9 @@ const RolesManager = ({ wcif, onWcifUpdate }) => {
                       {role.name}
                     </TableCell>
                   ))}
+                  {anyCompetitorAssignment(localWcif) && (
+                    <TableCell align="center">Staffing count</TableCell>
+                  )}
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -155,6 +159,15 @@ const RolesManager = ({ wcif, onWcifUpdate }) => {
                           />
                         </TableCell>
                       ))}
+                      {anyCompetitorAssignment(localWcif) && (
+                        <TableCell align="center">
+                          {
+                            person.assignments?.filter(assignment =>
+                              assignment.assignmentCode.startsWith('staff-')
+                            ).length
+                          }
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))}
               </TableBody>


### PR DESCRIPTION
It would be useful to be able to check directly in Groupifier how many assignments each person have. I'm not sure if this is the best place to put this, maybe separate tab would be better? 