### PR TITLE
Do not print scramble checker signature box for NR25 in single

### DIFF
--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -52,7 +52,7 @@
       "type": "boolean"
     },
     "printScrambleCheckerForTopRankedCompetitors": {
-      "description": "A flag indicating whether the box for scramble checker signature should be printed for top-ranked competitors (WR100/NR25 in single or WR50/NR15 in average).",
+      "description": "A flag indicating whether the box for scramble checker signature should be printed for top-ranked competitors (WR100 in single or WR50/NR15 in average).",
       "type": "boolean"
     },
     "printScrambleCheckerForFinalRounds": {

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -272,7 +272,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
                   onChange={handleCheckboxChange}
                 />
               }
-              label="Print out scramble checker sign box for top ranked competitors (WR100/NR25 in single or WR50/NR15 in average)"
+              label="Print out scramble checker sign box for top ranked competitors (WR100 in single or WR50/NR15 in average)"
             />
           </Grid>
           <Grid>

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -282,9 +282,7 @@ const shouldPrintScrambleChecker = (competitor, round, wcif) => {
         personalBest.eventId === eventId && personalBest.type === 'average'
     );
     if (
-      (singlePersonalBest &&
-        (singlePersonalBest.worldRanking <= 100 ||
-          singlePersonalBest.nationalRanking <= 25)) ||
+      (singlePersonalBest && singlePersonalBest.worldRanking <= 50) ||
       (averagePersonalBest &&
         (averagePersonalBest.worldRanking <= 50 ||
           averagePersonalBest.nationalRanking <= 15))


### PR DESCRIPTION
After a few competitions with this feature and talking with some organizers and delegates I realized that too many competitors have the scramble checker signature box on their scorecards and therefore it takes significant resources for double-checking scrambles for competitors who have for example a good single in 2x2. It also may cause scramblers to be less attentive to that if a lot of competitors have this box on their scorecards and therefore, there is a higher possibility for a misscramble. 

I've also considered allowing people to input the ranking position manually, but I'm not sure whether it's a good idea, would appreciate some thoughts on this matter.