### PR TITLE
Add person info dialog to groups editor

### DIFF
--- a/src/components/Competition/GroupsManager/GroupsEditor/DraggableCompetitor/DraggableCompetitor.js
+++ b/src/components/Competition/GroupsManager/GroupsEditor/DraggableCompetitor/DraggableCompetitor.js
@@ -1,32 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import { Draggable } from 'react-beautiful-dnd';
 
 import { best } from '../../../../../logic/competitors';
 import { centisecondsToClockFormat } from '../../../../../logic/formatters';
+import PersonInfoDialog from '../PersonInfoDialog/PersonInfoDialog';
 
 const DraggableCompetitor = React.memo(
   ({ person, draggableId, index, averageLabelEventId = null, ...props }) => {
+    const [isOpen, setIsOpen] = useState(false);
     const average =
       averageLabelEventId && best(person, averageLabelEventId, 'average');
     const averageDescription =
       average < Infinity ? ` (${centisecondsToClockFormat(average)})` : '';
 
     return (
-      <Draggable draggableId={draggableId} index={index}>
-        {provided => (
-          <ListItem
-            {...props}
-            button
-            ref={provided.innerRef}
-            {...provided.draggableProps}
-            {...provided.dragHandleProps}
-          >
-            <ListItemText primary={person.name + averageDescription} />
-          </ListItem>
+      <>
+        <Draggable draggableId={draggableId} index={index}>
+          {provided => (
+            <ListItem
+              {...props}
+              button
+              ref={provided.innerRef}
+              {...provided.draggableProps}
+              {...provided.dragHandleProps}
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <ListItemText primary={person.name + averageDescription} />
+            </ListItem>
+          )}
+        </Draggable>
+        {isOpen && (
+          <PersonInfoDialog person={person} onClose={() => setIsOpen(false)} />
         )}
-      </Draggable>
+      </>
     );
   }
 );

--- a/src/components/Competition/GroupsManager/GroupsEditor/PersonInfoDialog/PersonInfoDialog.js
+++ b/src/components/Competition/GroupsManager/GroupsEditor/PersonInfoDialog/PersonInfoDialog.js
@@ -97,7 +97,7 @@ const PersonInfoDialog = ({ person, onClose }) => {
         </Typography>
         {assignmentCodes.map(code => (
           <Typography key={code}>
-            {assignmentName(code)} - {assignmentsCount(code)} times
+            {assignmentName(code)}: {assignmentsCount(code)} times
           </Typography>
         ))}
       </DialogContent>

--- a/src/components/Competition/GroupsManager/GroupsEditor/PersonInfoDialog/PersonInfoDialog.js
+++ b/src/components/Competition/GroupsManager/GroupsEditor/PersonInfoDialog/PersonInfoDialog.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Avatar, Box, Link, Tooltip, Typography } from '@material-ui/core';
+import { age } from '../../../../../logic/competitors';
+import {
+  assignmentCodes,
+  assignmentName,
+  roleName,
+} from '../../../../../logic/assignments';
+import { WCA_ORIGIN } from '../../../../../logic/wca-env';
+import { eventNameById } from '../../../../../logic/events';
+import CubingIcon from '../../../../common/CubingIcon/CubingIcon';
+
+const PersonInfoDialog = ({ person, onClose }) => {
+  const assignmentsCount = code =>
+    person.assignments?.filter(assignment =>
+      assignment.assignmentCode.startsWith(code)
+    ).length;
+
+  return (
+    <Dialog open={true} onClose={onClose}>
+      <DialogTitle>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+          }}
+        >
+          <Avatar src={person.avatar?.thumbUrl} alt={person.name} />
+          <Box display="flex" flexDirection="column" overflow="hidden">
+            <Typography>
+              {person.name}{' '}
+              {person.wcaId && (
+                <Link
+                  href={`${WCA_ORIGIN}/persons/${person.wcaId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  ({person.wcaId})
+                </Link>
+              )}
+            </Typography>
+            <Typography variant="subtitle2" noWrap>
+              {person.roles?.length > 0 &&
+                person.roles.map(role => roleName(role)).join(', ')}
+            </Typography>
+          </Box>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 2,
+            height: 'fit-content',
+            mb: 2,
+          }}
+        >
+          {person.registration?.eventIds?.length > 0 &&
+            person.registration.eventIds.map(eventId => (
+              <Tooltip
+                key={eventId}
+                title={eventNameById(eventId)}
+                placement="top"
+              >
+                <Box>
+                  <CubingIcon eventId={eventId} />
+                </Box>
+              </Tooltip>
+            ))}
+        </Box>
+        {person.birthdate && (
+          <Typography>
+            Age: {age(person)} years old (
+            {new Date(person.birthdate).toLocaleDateString()})
+          </Typography>
+        )}
+        {person?.registration?.comments?.length > 0 && (
+          <Typography>
+            Registration comment: {person.registration.comments}
+          </Typography>
+        )}
+        {person?.registration?.administrativeNotes?.length > 0 && (
+          <Typography>
+            Administrative notes: {person.registration.administrativeNotes}
+          </Typography>
+        )}
+        <Typography>
+          Total staff assignments: {assignmentsCount('staff-')}
+        </Typography>
+        {assignmentCodes.map(code => (
+          <Typography key={code}>
+            {assignmentName(code)} - {assignmentsCount(code)} times
+          </Typography>
+        ))}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="secondary">
+          Ok
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PersonInfoDialog;

--- a/src/logic/assignments.js
+++ b/src/logic/assignments.js
@@ -14,6 +14,7 @@ export const DELEGATE_ROLE = 'delegate';
 export const TRAINEE_DELEGATE_ROLE = 'trainee-delegate';
 export const ORGANIZER_ROLE = 'organizer';
 export const DATA_ENTRY_ROLE = 'staff-dataentry';
+export const OTHER_ROLE = 'staff-other';
 
 export const assignmentCodes = [
   COMPETITOR_ASSIGNMENT_CODE,
@@ -47,6 +48,8 @@ export const roleName = role => {
       return 'Organizer';
     case DATA_ENTRY_ROLE:
       return 'Data Entry';
+    case OTHER_ROLE:
+      return 'Other Staff';
     default:
       //The rest of the roles are the same as assignment codes
       return assignmentName(role);

--- a/src/logic/assignments.js
+++ b/src/logic/assignments.js
@@ -10,6 +10,10 @@ export const COMPETITOR_ASSIGNMENT_CODE = 'competitor';
 export const SCRAMBLER_ASSIGNMENT_CODE = 'staff-scrambler';
 export const RUNNER_ASSIGNMENT_CODE = 'staff-runner';
 export const JUDGE_ASSIGNMENT_CODE = 'staff-judge';
+export const DELEGATE_ROLE = 'delegate';
+export const TRAINEE_DELEGATE_ROLE = 'trainee-delegate';
+export const ORGANIZER_ROLE = 'organizer';
+export const DATA_ENTRY_ROLE = 'staff-dataentry';
 
 export const assignmentCodes = [
   COMPETITOR_ASSIGNMENT_CODE,
@@ -30,6 +34,22 @@ export const assignmentName = assignmentCode => {
       return 'Judge';
     default:
       throw new Error(`Unrecognised assignment code: '${assignmentCode}'`);
+  }
+};
+
+export const roleName = role => {
+  switch (role) {
+    case DELEGATE_ROLE:
+      return 'Delegate';
+    case TRAINEE_DELEGATE_ROLE:
+      return 'Trainee Delegate';
+    case ORGANIZER_ROLE:
+      return 'Organizer';
+    case DATA_ENTRY_ROLE:
+      return 'Data Entry';
+    default:
+      //The rest of the roles are the same as assignment codes
+      return assignmentName(role);
   }
 };
 


### PR DESCRIPTION
Sometimes it'd useful to have some information about competitors directly in the edit groups view (i. e. their number of tasks or age). In this PR I added the dialog with some information about competitors which can be seen after clicking on the person's name.

https://github.com/user-attachments/assets/ccdd1a8d-ac2f-49b0-9e99-6f0f1755c3a4

