### PR TITLE
Fix OTS scorecards

### DIFF
--- a/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
+++ b/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
@@ -60,7 +60,7 @@ const OTSScorecards = ({ wcif }) => {
                 <ListItemAvatar>
                   <Avatar
                     alt={scorecards.person.name}
-                    src={scorecards.person.avatar.thumbUrl}
+                    src={scorecards.person.avatar?.thumbUrl}
                   />
                 </ListItemAvatar>
                 <ListItemText


### PR DESCRIPTION
After merging #111, I noticed that avatar can be `null`, and the page will go blank if one of the OTS registrations doesn't have an avatar. IDK why it was working locally for a person without an avatar, it looks like some people have a dummy avatar instead of `null`.
